### PR TITLE
Refactor Provider Registration

### DIFF
--- a/supergsl/core/exception.py
+++ b/supergsl/core/exception.py
@@ -21,7 +21,7 @@ class FunctionNotFoundError(NotFoundError):
     pass
 
 
-class PartNotFoundError(Exception):
+class PartNotFoundError(NotFoundError):
     pass
 
 

--- a/supergsl/core/function.py
+++ b/supergsl/core/function.py
@@ -4,11 +4,12 @@ import re
 from typing import Optional, List
 from inspect import getdoc
 from re import Pattern, Match
+from supergsl.core.plugin import SuperGSLProvider
 from supergsl.core.backend import DepthFirstNodeFilteredPass
 from supergsl.core.exception import FunctionInvokeError, FunctionNotFoundError
 
 
-class SuperGSLFunction(object):
+class SuperGSLFunction(SuperGSLProvider):
     """Add a callable function to SuperGSL."""
 
     name: Optional[str] = None

--- a/supergsl/core/function.py
+++ b/supergsl/core/function.py
@@ -4,7 +4,7 @@ import re
 from typing import Optional, List
 from inspect import getdoc
 from re import Pattern, Match
-from supergsl.core.plugin import SuperGSLProvider
+from supergsl.core.provider import SuperGSLProvider
 from supergsl.core.backend import DepthFirstNodeFilteredPass
 from supergsl.core.exception import FunctionInvokeError, FunctionNotFoundError
 

--- a/supergsl/core/lexer.py
+++ b/supergsl/core/lexer.py
@@ -9,7 +9,7 @@ class Lexer():
         # Reserved Words
         self.lexer.add('FROM', r'from')
         self.lexer.add('IMPORT', r'import')
-        self.lexer.add('AS', r'as')
+        self.lexer.add('AS', r'as\ ')
 
         # Other characters
         self.lexer.add('OPEN_PAREN', r'\(')

--- a/supergsl/core/parts/provider.py
+++ b/supergsl/core/parts/provider.py
@@ -3,7 +3,8 @@ from re import Pattern, Match
 from typing import Optional
 from supergsl.utils import import_class
 from supergsl.core.exception import ConfigurationError
-from supergsl.core.plugin import SuperGSLPlugin, SuperGSLProvider
+from supergsl.core.plugin import SuperGSLPlugin
+from supergsl.core.provider import SuperGSLProvider
 from supergsl.core.parts import Part, SeqPosition
 
 
@@ -64,7 +65,8 @@ class PartProviderPlugin(SuperGSLPlugin):
         self._providers = {}
 
         if 'part_providers' not in self.settings:
-            raise ConfigurationError('No part providers have been defined. Check your supergGSL settings.')
+            raise ConfigurationError(
+                'No part providers have been defined. Check your supergGSL settings.')
 
         for provider_config in self.settings['part_providers']:
             print('Initializing "%s"' % provider_config['name'])

--- a/supergsl/core/parts/provider.py
+++ b/supergsl/core/parts/provider.py
@@ -3,10 +3,11 @@ from re import Pattern, Match
 from typing import Optional
 from supergsl.utils import import_class
 from supergsl.core.exception import ConfigurationError
-from supergsl.core.plugin import SuperGSLPlugin
+from supergsl.core.plugin import SuperGSLPlugin, SuperGSLProvider
 from supergsl.core.parts import Part, SeqPosition
 
-class PartProvider(object):
+
+class PartProvider(SuperGSLProvider):
     name : Optional[str] = None
 
     def __init__(self, name):
@@ -63,7 +64,7 @@ class PartProviderPlugin(SuperGSLPlugin):
         self._providers = {}
 
         if 'part_providers' not in self.settings:
-            raise ConfigurationException('No part providers have been defined. Check your supergGSL settings.')
+            raise ConfigurationError('No part providers have been defined. Check your supergGSL settings.')
 
         for provider_config in self.settings['part_providers']:
             print('Initializing "%s"' % provider_config['name'])

--- a/supergsl/core/plugin.py
+++ b/supergsl/core/plugin.py
@@ -1,10 +1,26 @@
 """Support for SuperGSL's plugin infrastructure."""
 
 import inspect
+from re import Pattern, Match
 import importlib
 from typing import Dict
 from supergsl.core.exception import ConfigurationError
 from supergsl.core.symbol_table import SymbolTable
+
+class SuperGSLProvider(object):
+
+    def resolve_import(self, identifier : str, alias : str) -> Pattern:
+        """Resolve an identifier to be imported from this provider.
+
+        Return a tuple with:
+            * A regular expression to match symbols against
+            * A callback method that given the actual identifier will return the `Part`.
+        """
+        raise NotImplementedError('Subclass to implement')
+
+    def get_symbol(self, identifier_match : Match):
+        raise NotImplementedError('Subclass to implement')
+
 
 class SuperGSLPlugin(object):
     """Base class for defining a SuperGSL Plugin.

--- a/supergsl/core/plugin.py
+++ b/supergsl/core/plugin.py
@@ -7,20 +7,6 @@ from typing import Dict
 from supergsl.core.exception import ConfigurationError
 from supergsl.core.symbol_table import SymbolTable
 
-class SuperGSLProvider(object):
-
-    def resolve_import(self, identifier : str, alias : str) -> Pattern:
-        """Resolve an identifier to be imported from this provider.
-
-        Return a tuple with:
-            * A regular expression to match symbols against
-            * A callback method that given the actual identifier will return the `Part`.
-        """
-        raise NotImplementedError('Subclass to implement')
-
-    def get_symbol(self, identifier_match : Match):
-        raise NotImplementedError('Subclass to implement')
-
 
 class SuperGSLPlugin(object):
     """Base class for defining a SuperGSL Plugin.

--- a/supergsl/core/provider.py
+++ b/supergsl/core/provider.py
@@ -1,8 +1,9 @@
-"""Support for SuperGSL's plugin infrastructure."""
+"""Support SuperGSL's symbol provider mechanism."""
 from re import Pattern, Match
 from supergsl.core.types import SuperGSLType
 
 class SuperGSLProvider(object):
+    """Base class to define objects that can provide symbols."""
 
     def resolve_import(self, identifier : str, alias : str) -> Pattern:
         """Resolve an identifier to be imported from this provider.

--- a/supergsl/core/provider.py
+++ b/supergsl/core/provider.py
@@ -1,0 +1,17 @@
+"""Support for SuperGSL's plugin infrastructure."""
+from re import Pattern, Match
+from supergsl.core.types import SuperGSLType
+
+class SuperGSLProvider(object):
+
+    def resolve_import(self, identifier : str, alias : str) -> Pattern:
+        """Resolve an identifier to be imported from this provider.
+
+        Return a tuple with:
+            * A regular expression to match symbols against
+            * A callback method that given the actual identifier will return the `Part`.
+        """
+        raise NotImplementedError('Subclass to implement')
+
+    def get_symbol(self, identifier_match : Match) -> SuperGSLType:
+        raise NotImplementedError('Subclass to implement')

--- a/supergsl/core/symbol_table.py
+++ b/supergsl/core/symbol_table.py
@@ -1,5 +1,5 @@
 from re import Pattern
-from typing import Optional, Tuple, List, Dict, Type
+from typing import Optional, Tuple, List, Dict
 from collections import OrderedDict
 from supergsl.core.exception import SymbolNotFoundError, ProviderNotFoundError, NotFoundError
 from supergsl.core.provider import SuperGSLProvider
@@ -8,18 +8,18 @@ from supergsl.core.provider import SuperGSLProvider
 class SymbolTable(object):
 
     def __init__(self):
-        self._import_path_to_providers : Dict[str, List[Type[SuperGSLProvider]]] = {}
+        self._import_path_to_providers : Dict[str, List[SuperGSLProvider]] = {}
         self._symbols_providers: List[Tuple[Pattern, SuperGSLProvider]] = []
         self._symbols = {}
 
-    def register(self, provider_import_path: str, provider_class: Type[SuperGSLProvider]) -> None:
+    def register(self, provider_import_path: str, provider_class: SuperGSLProvider) -> None:
         """Register a provider to be available for import a given import path."""
         try:
             self._import_path_to_providers[provider_import_path].append(provider_class)
         except KeyError:
             self._import_path_to_providers[provider_import_path] = [provider_class]
 
-    def get_providers_for_path(self, provider_import_path) -> List[Type[SuperGSLProvider]]:
+    def get_providers_for_path(self, provider_import_path) -> List[SuperGSLProvider]:
         """Return all providers associated with an import path."""
         providers = self._import_path_to_providers.get(provider_import_path, None)
         if not providers:
@@ -45,14 +45,14 @@ class SymbolTable(object):
         else:
             raise Exception('Alias "%s" imported twice.' % active_alias)
 
-        provider_classes = self.get_providers_for_path(import_path)
-        for provider_class in provider_classes:
+        providers = self.get_providers_for_path(import_path)
+        for provider in providers:
             try:
-                alias_pattern = provider_class.resolve_import(import_name, active_alias)
+                alias_pattern = provider.resolve_import(import_name, active_alias)
             except NotFoundError:
                 continue
 
-            self._symbols_providers.append((alias_pattern, provider_class))
+            self._symbols_providers.append((alias_pattern, provider))
             return self.get_symbol(active_alias)
 
         raise NotFoundError('Symbol "{}" could not be resolved in path "{}"'.format(

--- a/supergsl/core/symbol_table.py
+++ b/supergsl/core/symbol_table.py
@@ -1,6 +1,6 @@
+"""Implement the symbol table of the SuperGSL Compiler."""
 from re import Pattern
 from typing import Optional, Tuple, List, Dict
-from collections import OrderedDict
 from supergsl.core.exception import SymbolNotFoundError, ProviderNotFoundError, NotFoundError
 from supergsl.core.provider import SuperGSLProvider
 

--- a/supergsl/core/symbol_table.py
+++ b/supergsl/core/symbol_table.py
@@ -12,12 +12,12 @@ class SymbolTable(object):
         self._symbols_providers: List[Tuple[Pattern, SuperGSLProvider]] = []
         self._symbols = {}
 
-    def register(self, provider_import_path: str, provider_class: SuperGSLProvider) -> None:
+    def register(self, provider_import_path: str, provider_inst: SuperGSLProvider) -> None:
         """Register a provider to be available for import a given import path."""
         try:
-            self._import_path_to_providers[provider_import_path].append(provider_class)
+            self._import_path_to_providers[provider_import_path].append(provider_inst)
         except KeyError:
-            self._import_path_to_providers[provider_import_path] = [provider_class]
+            self._import_path_to_providers[provider_import_path] = [provider_inst]
 
     def get_providers_for_path(self, provider_import_path) -> List[SuperGSLProvider]:
         """Return all providers associated with an import path."""

--- a/supergsl/core/test/test_lexer.py
+++ b/supergsl/core/test/test_lexer.py
@@ -59,7 +59,7 @@ examples = [
         ('IDENTIFIER', 'S288C'),
         ('IMPORT', 'import'),
         ('IDENTIFIER', 'ADHA'),
-        ('AS', 'as'),
+        ('AS', 'as '),
         ('IDENTIFIER', 'ADHA_is_great'),
         ('COMMA', ','),
         ('IDENTIFIER', 'ERG10'),

--- a/supergsl/core/test/test_parser.py
+++ b/supergsl/core/test/test_parser.py
@@ -1,3 +1,4 @@
+"""Unit tests for the SuperGSL parser."""
 import unittest
 import mock
 from rply import Token
@@ -14,15 +15,15 @@ class ParserTestCase(unittest.TestCase):
         self.parser = ParserBuilder()
 
     def test_one_assembly_must_be_defined(self):
-        """Test that an error is raised if the parser does not receive tokens for at least one assembly."""
+        """An error should be raised if the parser does not receive tokens for at least one assembly."""
         tokens = iter(())
         error_message = None
         try:
-            ast = self.parser.parse(tokens)
+            self.parser.parse(tokens)
         except ParsingError as error:
             error_message = str(error)
 
-        self.assertEquals(
+        self.assertEqual(
             error_message,
             'At least one assembly must be defined.')
 
@@ -48,7 +49,7 @@ class ParserTestCase(unittest.TestCase):
         ast = self.parser.parse(tokens)
 
         self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'items': [{
                     'label': None,
@@ -82,8 +83,8 @@ class ParserTestCase(unittest.TestCase):
         ))
         ast = self.parser.parse(tokens)
 
-        self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'node': 'DefinitionList',
                 'items': [{
@@ -115,8 +116,8 @@ class ParserTestCase(unittest.TestCase):
         ))
         ast = self.parser.parse(tokens)
 
-        self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'node': 'DefinitionList',
                 'items': [{
@@ -144,6 +145,7 @@ class ParserTestCase(unittest.TestCase):
         })
 
     def test_build_ast_function_call_with_empty_params(self):
+        """Parse a AST containing a function with a nested body into an AST."""
         tokens = iter((
             Token('IDENTIFIER', 'functest'),
             Token('OPEN_CURLY_BRACKET', '{'),
@@ -152,8 +154,8 @@ class ParserTestCase(unittest.TestCase):
         ))
         ast = self.parser.parse(tokens)
 
-        self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'node': 'DefinitionList',
                 'items': [{
@@ -181,6 +183,7 @@ class ParserTestCase(unittest.TestCase):
         })
 
     def test_build_ast_function_call_with_params(self):
+        """Parse a function call into a AST."""
         tokens = iter((
             Token('IDENTIFIER', 'functest'),
             Token('OPEN_PAREN', '('),
@@ -189,8 +192,8 @@ class ParserTestCase(unittest.TestCase):
         ))
         ast = self.parser.parse(tokens)
 
-        self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'node': 'DefinitionList',
                 'items': [{
@@ -208,6 +211,7 @@ class ParserTestCase(unittest.TestCase):
         })
 
     def test_build_ast_sequence_constant(self):
+        """Parse to an AST for a constant nucleotide sequence."""
         tokens = iter((
             Token('FORWARD_SLASH', '/'),
             Token('IDENTIFIER', 'ATGG'),
@@ -216,8 +220,8 @@ class ParserTestCase(unittest.TestCase):
         ))
         ast = self.parser.parse(tokens)
 
-        self.assertEquals(type(ast), Program)
-        self.assertEquals(ast.eval(), {
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.eval(), {
             'definitions': {
                 'node': 'DefinitionList',
                 'items': [{

--- a/supergsl/core/test/test_symbol_table.py
+++ b/supergsl/core/test/test_symbol_table.py
@@ -1,0 +1,28 @@
+import unittest
+import mock
+from supergsl.core.symbol_table import SymbolTable
+from supergsl.core.provider import SuperGSLProvider
+
+class SymbolTableTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.table = SymbolTable()
+
+    def test_register_and_get_providers(self):
+        """Register providers for a specific path and then retrieve it."""
+
+        class MockProvider(SuperGSLProvider):
+            pass
+
+        class MockProvider2(SuperGSLProvider):
+            pass
+
+        self.table.register('impor.this.path', MockProvider)
+        self.table.register('impor.this.path', MockProvider2)
+
+        providers = self.table.get_providers_for_path('impor.this.path')
+
+        self.assertEquals(providers, [
+            MockProvider,
+            MockProvider2
+        ])

--- a/supergsl/core/test/test_symbol_table.py
+++ b/supergsl/core/test/test_symbol_table.py
@@ -1,5 +1,6 @@
+"""Unit tests for the symbol table."""
 import unittest
-import mock
+from mock import Mock
 from supergsl.core.symbol_table import SymbolTable
 from supergsl.core.provider import SuperGSLProvider
 
@@ -14,15 +15,16 @@ class SymbolTableTestCase(unittest.TestCase):
         class MockProvider(SuperGSLProvider):
             pass
 
-        class MockProvider2(SuperGSLProvider):
-            pass
+        provider1 = MockProvider()
+        provider2 = MockProvider()
 
-        self.table.register('impor.this.path', MockProvider)
-        self.table.register('impor.this.path', MockProvider2)
+        self.table.register('impor.this.path', provider1)
+        self.table.register('impor.this.path', provider2)
 
         providers = self.table.get_providers_for_path('impor.this.path')
 
         self.assertEquals(providers, [
-            MockProvider,
-            MockProvider2
+            provider1,
+            provider2
         ])
+


### PR DESCRIPTION
Want to be able to define multiple providers at the same import path. Need some logic such that the symbol table iterates over each provider for a given paths and attempts to import the desired symbol.