### PR TITLE
Support multiline import statements.

### DIFF
--- a/supergsl/core/parser.py
+++ b/supergsl/core/parser.py
@@ -84,9 +84,17 @@ class ParserBuilder(object):
 
             return [p[0]]
 
+        @self.pg.production('import : FROM import_module IMPORT OPEN_PAREN import_identifiers CLOSE_PAREN')
         @self.pg.production('import : FROM import_module IMPORT import_identifiers')
         def program_import(state, p):
-            return ast.Import(p[1], p[3])
+            if len(p) == 6:
+                import_module = p[1]
+                import_identifiers = p[4]
+            if len(p) == 4:
+                import_module = p[1]
+                import_identifiers = p[3]
+
+            return ast.Import(import_module, import_identifiers)
 
         @self.pg.production('import_module : import_module PERIOD IDENTIFIER')
         @self.pg.production('import_module : IDENTIFIER')

--- a/supergsl/core/tests/test_parser.py
+++ b/supergsl/core/tests/test_parser.py
@@ -62,6 +62,56 @@ class ParserTestCase(unittest.TestCase):
             'node': 'Program'
         })
 
+    def test_multiline_import(self):
+        """Confirm parser can handle a multi-line import statement."""
+        tokens = iter((
+            # Import
+            Token('FROM', 'from'),
+            Token('IDENTIFIER', 'S288C'),
+            Token('IMPORT', 'import'),
+            Token('OPEN_PAREN', '('),
+            Token('IDENTIFIER', 'ADHA'),
+            Token('AS', 'as'),
+            Token('IDENTIFIER', 'BLOOP'),
+            Token('COMMA', ','),
+            Token('IDENTIFIER', 'ERG10'),
+            Token('COMMA', ','),
+            Token('IDENTIFIER', 'HO'),
+            Token('CLOSE_PAREN', ')'),
+
+            # Single Assembly
+            Token('IDENTIFIER', 'uHO'),
+        ))
+        ast = self.parser.parse(tokens)
+
+        self.assertEqual(type(ast), Program)
+        self.assertEqual(ast.to_dict(), {
+            'definitions': {
+                'items': [{
+                    'label': None,
+                    'node': 'Assembly',
+                    'parts': [{
+                        'node': 'SymbolReference',
+                        'identifier': 'uHO',
+                        'invert': False,
+                        'slice': None
+                    }]
+                }],
+                'node': 'DefinitionList'
+            },
+            'imports': [{
+                'imports': [
+                    {'alias': 'BLOOP', 'identifier': 'ADHA'},
+                    {'alias': None, 'identifier': 'ERG10'},
+                    {'alias': None, 'identifier': 'HO'}
+                ],
+                'module': ['S288C'],
+                'node': 'Import'
+            }],
+            'node': 'Program'
+        })
+
+
     def test_build_ast_assembly(self):
         tokens = iter((
             Token('IDENTIFIER', 'uHO'),


### PR DESCRIPTION
Desired syntax:

```
from tab.S288C import (
    GAL3 as GALIZAR,
    GAL1 as AnotherGreatGAL
)
```